### PR TITLE
Add trimmed mean

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -58,6 +58,12 @@ Functions
     T-digest and array of values between 0 and 1 which represent the quantiles
     to return.
 
+.. function:: trimmed_mean(tdigest<double>, lower_quantile, upper_quantile) -> double
+
+    Returns an estimate of the mean, excluding portions of the distribution
+    outside the provided quantile bounds. Both ``lower_quantile`` and ``upper_quantile``
+    must be between 0 and 1.
+
 .. function:: tdigest_agg(x) -> tdigest<double>
 
     Returns the ``tdigest`` which is composed of  all input values of ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -140,11 +140,11 @@ public final class TDigestFunctions
     @ScalarFunction(value = "trimmed_mean", visibility = EXPERIMENTAL)
     @Description("Returns an estimate of the mean, excluding portions of the distribution outside the provided quantile bounds.")
     @SqlType("double")
-    public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerPercentileBound, @SqlType(StandardTypes.DOUBLE) double upperPercentileBound)
+    public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerQuantileBound, @SqlType(StandardTypes.DOUBLE) double upperQuantileBound)
     {
-        checkCondition(lowerPercentileBound >= 0 && lowerPercentileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Lower percentile bound should be in [0,1].");
-        checkCondition(upperPercentileBound >= 0 && upperPercentileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Upper percentile bound should be in [0,1].");
+        checkCondition(lowerQuantileBound >= 0 && lowerQuantileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Lower quantile bound should be in [0,1].");
+        checkCondition(upperQuantileBound >= 0 && upperQuantileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Upper quantile bound should be in [0,1].");
         TDigest digest = createTDigest(input);
-        return digest.trimmedMean(lowerPercentileBound, upperPercentileBound);
+        return digest.trimmedMean(lowerQuantileBound, upperQuantileBound);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -136,4 +136,15 @@ public final class TDigestFunctions
         blockBuilder.closeEntry();
         return TDIGEST_CENTROIDS_ROW_TYPE.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
     }
+
+    @ScalarFunction(value = "trimmed_mean", visibility = EXPERIMENTAL)
+    @Description("Returns an estimate of the mean, after trimming to keep only the given percentile bounds")
+    @SqlType("double")
+    public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerPercentileBound, @SqlType(StandardTypes.DOUBLE) double upperPercentileBound)
+    {
+        checkCondition(lowerPercentileBound >= 0 && lowerPercentileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Lower percentile bound should be in [0,1].");
+        checkCondition(upperPercentileBound >= 0 && upperPercentileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Upper percentile bound should be in [0,1].");
+        TDigest digest = createTDigest(input);
+        return digest.trimmedMean(lowerPercentileBound, upperPercentileBound);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -138,7 +138,7 @@ public final class TDigestFunctions
     }
 
     @ScalarFunction(value = "trimmed_mean", visibility = EXPERIMENTAL)
-    @Description("Returns an estimate of the mean, after trimming to keep only the given percentile bounds")
+    @Description("Returns an estimate of the mean, excluding portions of the distribution outside the provided percentile bounds")
     @SqlType("double")
     public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerPercentileBound, @SqlType(StandardTypes.DOUBLE) double upperPercentileBound)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -138,7 +138,7 @@ public final class TDigestFunctions
     }
 
     @ScalarFunction(value = "trimmed_mean", visibility = EXPERIMENTAL)
-    @Description("Returns an estimate of the mean, excluding portions of the distribution outside the provided percentile bounds")
+    @Description("Returns an estimate of the mean, excluding portions of the distribution outside the provided quantile bounds.")
     @SqlType("double")
     public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerPercentileBound, @SqlType(StandardTypes.DOUBLE) double upperPercentileBound)
     {

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -566,25 +566,25 @@ public class TDigest
         return weightedAverage(mean[n - 1], z1, max, z2);
     }
 
-    public double trimmedMean(double l, double h)
+    public double trimmedMean(double l, double u)
     {
         checkArgument(l >= 0 && l <= 1, "l should be in [0,1], got %s", l);
-        checkArgument(h >= 0 && h <= 1, "h should be in [0,1], got %s", h);
+        checkArgument(u >= 0 && u <= 1, "u should be in [0,1], got %s", u);
 
         if (unmergedWeight > 0) {
             compress();
         }
 
-        if (activeCentroids == 0 || l >= h) {
+        if (activeCentroids == 0 || l >= u) {
             return Double.NaN;
         }
 
-        if (l == 0 && h == 1) {
+        if (l == 0 && u == 1) {
             return sum / totalWeight;
         }
 
-        double lowIndex = l * totalWeight;
-        double highIndex = h * totalWeight;
+        double lowerIndex = l * totalWeight;
+        double upperIndex = u * totalWeight;
 
         int n = activeCentroids;
 
@@ -592,21 +592,21 @@ public class TDigest
         double sumInBounds = 0;
         double weightInBounds = 0;
         for (int i = 0; i < n; i++) {
-            if (weightSoFar < lowIndex && lowIndex <= weightSoFar + weight[i] && highIndex <= weightSoFar + weight[i]) {
+            if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i] && upperIndex <= weightSoFar + weight[i]) {
                 // lower and upper bounds are so close together that they are in the same weight interval
                 return mean[i];
-            } else if (weightSoFar < lowIndex && lowIndex <= weightSoFar + weight[i]) {
+            } else if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i]) {
                 // the lower bound is between our current point and the next point
-                double addedWeight = weightSoFar + weight[i] - lowIndex;
+                double addedWeight = weightSoFar + weight[i] - lowerIndex;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
-            } else if (highIndex < weightSoFar + weight[i] && highIndex > weightSoFar) {
+            } else if (upperIndex < weightSoFar + weight[i] && upperIndex > weightSoFar) {
                 // the upper bound is between our current point and the next point
-                double addedWeight = highIndex - weightSoFar;
+                double addedWeight = upperIndex - weightSoFar;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
                 return sumInBounds / weightInBounds;
-            } else if (lowIndex <= weightSoFar && weightSoFar <= highIndex) {
+            } else if (lowerIndex <= weightSoFar && weightSoFar <= upperIndex) {
                 // we are somewhere in between the lower and upper bounds
                 sumInBounds += mean[i] * weight[i];
                 weightInBounds += weight[i];

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -595,18 +595,21 @@ public class TDigest
             if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i] && upperIndex <= weightSoFar + weight[i]) {
                 // lower and upper bounds are so close together that they are in the same weight interval
                 return mean[i];
-            } else if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i]) {
+            }
+            else if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i]) {
                 // the lower bound is between our current point and the next point
                 double addedWeight = weightSoFar + weight[i] - lowerIndex;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
-            } else if (upperIndex < weightSoFar + weight[i] && upperIndex > weightSoFar) {
+            }
+            else if (upperIndex < weightSoFar + weight[i] && upperIndex > weightSoFar) {
                 // the upper bound is between our current point and the next point
                 double addedWeight = upperIndex - weightSoFar;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
                 return sumInBounds / weightInBounds;
-            } else if (lowerIndex <= weightSoFar && weightSoFar <= upperIndex) {
+            }
+            else if (lowerIndex <= weightSoFar && weightSoFar <= upperIndex) {
                 // we are somewhere in between the lower and upper bounds
                 sumInBounds += mean[i] * weight[i];
                 weightInBounds += weight[i];

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -591,7 +591,7 @@ public class TDigest
         double weightSoFar = 0;
         double sumInBounds = 0;
         double weightInBounds = 0;
-        for (int i = 0; i < n - 1; i++) {
+        for (int i = 0; i < n; i++) {
             if (weightSoFar < lowIndex && lowIndex <= weightSoFar + weight[i] && highIndex <= weightSoFar + weight[i]) {
                 // lower and upper bounds are so close together that they are in the same weight interval
                 return mean[i];

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -596,15 +596,18 @@ public class TDigest
                 // lower and upper bounds are so close together that they are in the same weight interval
                 return mean[i];
             } else if (weightSoFar < lowIndex && lowIndex <= weightSoFar + weight[i]) {
+                // the lower bound is between our current point and the next point
                 double addedWeight = weightSoFar + weight[i] - lowIndex;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
             } else if (highIndex < weightSoFar + weight[i] && highIndex > weightSoFar) {
+                // the upper bound is between our current point and the next point
                 double addedWeight = highIndex - weightSoFar;
                 sumInBounds += mean[i] * addedWeight;
                 weightInBounds += addedWeight;
                 return sumInBounds / weightInBounds;
             } else if (lowIndex <= weightSoFar && weightSoFar <= highIndex) {
+                // we are somewhere in between the lower and upper bounds
                 sumInBounds += mean[i] * weight[i];
                 weightInBounds += weight[i];
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -146,17 +146,15 @@ public class TestTDigestFunctions
         }
 
         functionAssertions.assertFunction(
-                format("quantile_at_value(CAST(X'%s' AS tdigest(%s)), %s) = 1",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("quantile_at_value(%s, %s) = 1",
+                        toSqlString(tDigest),
                         1_000_000_000d),
                 BOOLEAN,
                 true);
 
         functionAssertions.assertFunction(
-                format("quantile_at_value(CAST(X'%s' AS tdigest(%s)), %s) = 0",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("quantile_at_value(%s, %s) = 0",
+                        toSqlString(tDigest),
                         -500d),
                 BOOLEAN,
                 true);
@@ -428,9 +426,7 @@ public class TestTDigestFunctions
         double sum = values.stream().reduce(0.0d, Double::sum);
         long count = values.size();
 
-        String sql = format("destructure_tdigest(CAST(X'%s' AS tdigest(%s)))",
-                new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                DOUBLE);
+        String sql = format("destructure_tdigest(%s)", toSqlString(tDigest));
 
         functionAssertions.assertFunction(
                 sql,
@@ -469,9 +465,7 @@ public class TestTDigestFunctions
         double sum = values.stream().reduce(0.0d, Double::sum);
         long count = values.size();
 
-        String sql = format("destructure_tdigest(CAST(X'%s' AS tdigest(%s)))",
-                new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                DOUBLE);
+        String sql = format("destructure_tdigest(%s)", toSqlString(tDigest));
 
         functionAssertions.assertFunction(format("%s.compression", sql), DOUBLE, compression);
         functionAssertions.assertFunction(format("%s.min", sql), DOUBLE, min);
@@ -558,8 +552,8 @@ public class TestTDigestFunctions
 
         functionAssertions.selectSingleValue(
                 format(
-                        "scale_tdigest(CAST(X'%s' AS tdigest(double)), -1)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " ")),
+                        "scale_tdigest(%s, -1)",
+                        toSqlString(tDigest)),
                 TDIGEST_DOUBLE,
                 SqlVarbinary.class);
     }
@@ -575,9 +569,7 @@ public class TestTDigestFunctions
 
         // Scale up.
         SqlVarbinary sqlVarbinary = functionAssertions.selectSingleValue(
-                format(
-                        "scale_tdigest(CAST(X'%s' AS tdigest(double)), 2)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " ")),
+                format("scale_tdigest(%s, 2)", toSqlString(tDigest)),
                 TDIGEST_DOUBLE,
                 SqlVarbinary.class);
 
@@ -589,9 +581,7 @@ public class TestTDigestFunctions
 
         // Scale down.
         sqlVarbinary = functionAssertions.selectSingleValue(
-                format(
-                        "scale_tdigest(CAST(X'%s' AS tdigest(double)), 0.5)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " ")),
+                format("scale_tdigest(%s, 0.5)", toSqlString(tDigest)),
                 TDIGEST_DOUBLE,
                 SqlVarbinary.class);
 
@@ -613,17 +603,15 @@ public class TestTDigestFunctions
     private void assertValueWithinBound(double quantile, double error, List<Double> list, TDigest tDigest)
     {
         functionAssertions.assertFunction(
-                format("quantile_at_value(CAST(X'%s' AS tdigest(%s)), %s) <= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("quantile_at_value(%s, %s) <= %s",
+                        toSqlString(tDigest),
                         list.get((int) (NUMBER_OF_ENTRIES * quantile)),
                         getUpperBoundQuantile(quantile, error)),
                 BOOLEAN,
                 true);
         functionAssertions.assertFunction(
-                format("quantile_at_value(CAST(X'%s' AS tdigest(%s)), %s) >= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("quantile_at_value(%s, %s) >= %s",
+                        toSqlString(tDigest),
                         list.get((int) (NUMBER_OF_ENTRIES * quantile)),
                         getLowerBoundQuantile(quantile, error)),
                 BOOLEAN,
@@ -633,17 +621,15 @@ public class TestTDigestFunctions
     private void assertDiscreteQuantileWithinBound(double quantile, double error, List<Integer> list, TDigest tDigest)
     {
         functionAssertions.assertFunction(
-                format("round(value_at_quantile(CAST(X'%s' AS tdigest(%s)), %s)) <= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("round(value_at_quantile(%s, %s)) <= %s",
+                        toSqlString(tDigest),
                         quantile,
                         getUpperBoundValue(quantile, error, list)),
                 BOOLEAN,
                 true);
         functionAssertions.assertFunction(
-                format("round(value_at_quantile(CAST(X'%s' AS tdigest(%s)), %s)) >= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("round(value_at_quantile(%s, %s)) >= %s",
+                        toSqlString(tDigest),
                         quantile,
                         getLowerBoundValue(quantile, error, list)),
                 BOOLEAN,
@@ -653,17 +639,15 @@ public class TestTDigestFunctions
     private void assertContinuousQuantileWithinBound(double quantile, double error, List<Double> list, TDigest tDigest)
     {
         functionAssertions.assertFunction(
-                format("value_at_quantile(CAST(X'%s' AS tdigest(%s)), %s) <= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("value_at_quantile(%s, %s) <= %s",
+                        toSqlString(tDigest),
                         quantile,
                         getUpperBoundValue(quantile, error, list)),
                 BOOLEAN,
                 true);
         functionAssertions.assertFunction(
-                format("value_at_quantile(CAST(X'%s' AS tdigest(%s)), %s) >= %s",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        DOUBLE,
+                format("value_at_quantile(%s, %s) >= %s",
+                        toSqlString(tDigest),
                         quantile,
                         getLowerBoundValue(quantile, error, list)),
                 BOOLEAN,
@@ -708,9 +692,8 @@ public class TestTDigestFunctions
         // Ensure that the lower bound of each item in the distribution is not greater than the chosen quantiles
         functionAssertions.assertFunction(
                 format(
-                        "zip_with(values_at_quantiles(CAST(X'%s' AS tdigest(%s)), ARRAY[%s]), ARRAY[%s], (value, lowerbound) -> value >= lowerbound)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        "double",
+                        "zip_with(values_at_quantiles(%s, ARRAY[%s]), ARRAY[%s], (value, lowerbound) -> value >= lowerbound)",
+                        toSqlString(tDigest),
                         ARRAY_JOINER.join(boxedPercentiles),
                         ARRAY_JOINER.join(lowerBounds)),
                 METADATA.getType(parseTypeSignature("array(boolean)")),
@@ -719,9 +702,8 @@ public class TestTDigestFunctions
         // Ensure that the upper bound of each item in the distribution is not less than the chosen quantiles
         functionAssertions.assertFunction(
                 format(
-                        "zip_with(values_at_quantiles(CAST(X'%s' AS tdigest(%s)), ARRAY[%s]), ARRAY[%s], (value, upperbound) -> value <= upperbound)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        "double",
+                        "zip_with(values_at_quantiles(%s, ARRAY[%s]), ARRAY[%s], (value, upperbound) -> value <= upperbound)",
+                        toSqlString(tDigest),
                         ARRAY_JOINER.join(boxedPercentiles),
                         ARRAY_JOINER.join(upperBounds)),
                 METADATA.getType(parseTypeSignature("array(boolean)")),
@@ -738,9 +720,8 @@ public class TestTDigestFunctions
         // Ensure that the lower bound of each item in the distribution is not greater than the chosen quantiles
         functionAssertions.assertFunction(
                 format(
-                        "zip_with(quantiles_at_values(CAST(X'%s' AS tdigest(%s)), ARRAY[%s]), ARRAY[%s], (value, lowerbound) -> value >= lowerbound)",
-                        new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
-                        "double",
+                        "zip_with(quantiles_at_values(%s, ARRAY[%s]), ARRAY[%s], (value, lowerbound) -> value >= lowerbound)",
+                        toSqlString(tDigest),
                         ARRAY_JOINER.join(boxedValues),
                         ARRAY_JOINER.join(lowerBounds)),
                 METADATA.getType(parseTypeSignature("array(boolean)")),
@@ -756,5 +737,13 @@ public class TestTDigestFunctions
                         ARRAY_JOINER.join(upperBounds)),
                 METADATA.getType(parseTypeSignature("array(boolean)")),
                 Collections.nCopies(values.length, true));
+    }
+
+
+    private String toSqlString(TDigest tDigest)
+    {
+        return format("CAST(X'%s' AS tdigest(%s))",
+                new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
+                DOUBLE);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -747,22 +747,22 @@ public class TestTDigestFunctions
                 Collections.nCopies(percentiles.length, true));
     }
 
-    private void assertTrimmedMeanValues(List<Double> lowQuantiles, List<Double> highQuantiles, double error, List<? extends Number> rows, TDigest tDigest)
+    private void assertTrimmedMeanValues(List<Double> lowerQuantiles, List<Double> upperQuantiles, double error, List<? extends Number> rows, TDigest tDigest)
     {
-        List<Double> expectedTrimmedMeans = IntStream.range(0, lowQuantiles.size())
-                .mapToDouble(i -> getTrimmedMean(lowQuantiles.get(i), highQuantiles.get(i), rows))
+        List<Double> expectedTrimmedMeans = IntStream.range(0, lowerQuantiles.size())
+                .mapToDouble(i -> getTrimmedMean(lowerQuantiles.get(i), upperQuantiles.get(i), rows))
                 .boxed()
                 .collect(toImmutableList());
         functionAssertions.assertFunction(
                 format(
-                        "zip_with(ARRAY[%s], zip_with(ARRAY[%s], ARRAY[%s], (l, h) -> (l, h)), (v, bounds) -> abs(1-trimmed_mean(%s, bounds[1], bounds[2])/v) <= %s)",
+                        "zip_with(ARRAY[%s], zip_with(ARRAY[%s], ARRAY[%s], (l, u) -> (l, u)), (v, bounds) -> abs(1-trimmed_mean(%s, bounds[1], bounds[2])/v) <= %s)",
                         ARRAY_JOINER.join(expectedTrimmedMeans),
-                        ARRAY_JOINER.join(lowQuantiles),
-                        ARRAY_JOINER.join(highQuantiles),
+                        ARRAY_JOINER.join(lowerQuantiles),
+                        ARRAY_JOINER.join(upperQuantiles),
                         toSqlString(tDigest),
                         error),
                 METADATA.getType(parseTypeSignature("array(boolean)")),
-                Collections.nCopies(lowQuantiles.size(), true));
+                Collections.nCopies(lowerQuantiles.size(), true));
     }
 
     private void assertBlockValues(double[] values, double error, TDigest tDigest)

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -180,7 +180,7 @@ public class TestTDigest
         for (int i = 0; i < quantile.length; i++) {
             for (int j = i + 1; j < quantile.length; j++) {
                 assertTrimmedMean(quantile[i], quantile[j], STANDARD_ERROR * 2, list, tDigest);
-                // increase error bound to 2% (mean is less accurate than quartile values)
+                // increase error bound to 2% (mean is less accurate than quantile values)
                 // in practice, the difference is always < 2% for uniform distributions
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -453,6 +453,7 @@ public class TestTDigest
 
         sort(list);
 
+        // test all quantile combinations
         for (int i = 0; i < quantile.length; i++) {
             for (int j = i + 1; j < quantile.length; j++) {
                 assertTrimmedMean(quantile[i], quantile[j], Math.sqrt(distribution.getNumericalVariance()), TRIMMED_MEAN_ERROR_IN_DEVIATIONS, list, tDigest);
@@ -460,13 +461,13 @@ public class TestTDigest
         }
     }
 
-    private void assertTrimmedMean(double l, double h, double sd, double sigmaBound, List<Double> values, TDigest tDigest)
+    private void assertTrimmedMean(double lowerQuantileBound, double upperQuantileBound, double sd, double sigmaBound, List<Double> values, TDigest tDigest)
     {
         double expectedMean = values
-                .subList((int) (NUMBER_OF_ENTRIES * l), (int) (NUMBER_OF_ENTRIES * h) + 1)
+                .subList((int) (NUMBER_OF_ENTRIES * lowerQuantileBound), (int) (NUMBER_OF_ENTRIES * upperQuantileBound) + 1)
                 .stream()
-                .reduce(0.0d, Double::sum) / ((int) (NUMBER_OF_ENTRIES * h) - (int) (NUMBER_OF_ENTRIES * l) + 1);
-        double returnValue = tDigest.trimmedMean(l, h);
+                .reduce(0.0d, Double::sum) / ((int) (NUMBER_OF_ENTRIES * upperQuantileBound) - (int) (NUMBER_OF_ENTRIES * lowerQuantileBound) + 1);
+        double returnValue = tDigest.trimmedMean(lowerQuantileBound, upperQuantileBound);
         double standardizedError = Math.abs((returnValue - expectedMean) / sd);
         assertTrue(standardizedError <= sigmaBound,
                 format("Returned trimmed mean %s is %s sigma > %s from the actual trimmed mean %s", returnValue, standardizedError, sigmaBound, expectedMean));

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -181,7 +181,7 @@ public class TestTDigest
             for (int j = i + 1; j < quantile.length; j++) {
                 assertTrimmedMean(quantile[i], quantile[j], STANDARD_ERROR * 2, list, tDigest);
                 // increase error bound to 2% (mean is less accurate than quantile values)
-                // in practice, the difference is always < 2% for uniform distributions
+                // in practice, the difference is always < 2% for uniform distributions with compression=200
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.facebook.presto.tdigest.TDigest.createTDigest;
 import static java.lang.String.format;
@@ -439,17 +438,17 @@ public class TestTDigest
         assertEquals(tDigest.getSum(), expectedSum, 0.0001);
     }
 
-    private void assertTrimmedMean(double lowQuantile, double highQuantile, double bound, List<Double> values, TDigest tDigest)
+    private void assertTrimmedMean(double l, double h, double bound, List<Double> values, TDigest tDigest)
     {
-        double lowerQuantile = values.get((int) (NUMBER_OF_ENTRIES * lowQuantile));
-        double upperQuantile = values.get((int) (NUMBER_OF_ENTRIES * highQuantile));
+        double lowQuantile = values.get((int) (NUMBER_OF_ENTRIES * l));
+        double highQuantile = values.get((int) (NUMBER_OF_ENTRIES * h));
 
         double expectedMean = values.stream()
-                .filter(v -> lowerQuantile <= v && v <= upperQuantile)
+                .filter(v -> lowQuantile <= v && v <= highQuantile)
                 .mapToDouble(v -> v)
                 .average()
                 .orElse(Double.NaN);
-        double returnValue = tDigest.trimmedMean(lowQuantile, highQuantile);
+        double returnValue = tDigest.trimmedMean(l, h);
         double percentError = (returnValue - expectedMean) / (values.get(NUMBER_OF_ENTRIES - 1) - values.get(0));
         assertTrue(percentError <= bound,
                 format("Returned trimmed mean %s is has more than %s%% difference with the expected trimmed mean %s", returnValue, bound*100, expectedMean));


### PR DESCRIPTION
- Add `trimmedMean` to TDigest to compute the estimated [trimmed mean](https://en.wikipedia.org/wiki/Truncated_mean) given lower and upper percentile bounds
- Add the `trimmed_mean` as a scalar Presto function

It implements the following calculation, which as far as I understand is the same as the algorithm implemented in [python's tdigest](https://github.com/CamDavidsonPilon/tdigest/blob/master/tdigest/tdigest.py#L216).
![tdigest_trimmed_mean drawio (2)](https://user-images.githubusercontent.com/23248585/173343999-9694760a-65b0-48bb-80f7-7cd4355910db.png)
Test plan:
`mvn -Dtest="TestTDigest,TestTDigestFunctions" test`

- ensured that the returned estimated trimmed mean is ±0.05σ from the actual trimmed mean in TDigest. Tested for uniform, normal and Poisson distributions, accross all lower/upper quantile combinations. Disabled most of the tests for performance.
- followed the same logic to test the Presto function

```
== RELEASE NOTES ==

General Changes
* Added TRIMMED_MEAN() for Tdigest. The prototype of the function is:

TRIMMED_MEAN(tdigest: TDIGEST, lower_quantile: DOUBLE, upper_quantile: DOUBLE) -> DOUBLE
```
